### PR TITLE
Some CI improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
-
   pull_request:
     branches: [master]
 
@@ -22,7 +19,7 @@ jobs:
         uses: GsActions/commit-message-checker@v1
         with:
           # A regex pattern to check if a commit message is valid.
-          pattern: "((\\[(builder|changelog|ci|cmake|codegen|core|doc|docs|git|sc-kpm|sc-memory|sc-network|sc-server|scripts|scs|test|tests|thirdparty|web)\\])+(.)+)|(Review fixes)|(Merge pull request #[0-9]+ .+)$"
+          pattern: "((\\[(builder|changelog|ci|cmake|codegen|core|doc|docs|git|sc-kpm|sc-memory|sc-network|sc-server|scripts|scs|test|tests|thirdparty|web)\\])+(.)+)|(Review fixes)$"
           # Expression flags change how the expression is interpreted.
           flags: "" # optional, default is gm
           # A error message which will be returned in case of an error.

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,9 +1,6 @@
 name: Sanitizers
 
 on:
-  push:
-    branches: [master]
-
   pull_request:
     branches: [master]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # SC-machine
 
-[![CI](https://github.com/ostis-dev/sc-machine/actions/workflows/main.yml/badge.svg)](https://github.com/ostis-dev/sc-machine/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/ostis-dev/sc-machine/branch/master/graph/badge.svg?token=PqItjd03eH)](https://codecov.io/gh/ostis-dev/sc-machine)
 
 ## Documentation


### PR DESCRIPTION
All PR's merged into `master` branch are covered by CI and require rebase before merging.
So we don't need badge in readme.

Close #409

Also fix codecov integration. And replaced upload logic with actions, because [upload bash is deprecated](https://docs.codecov.com/docs/about-the-codecov-bash-uploader)